### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,17 @@ npm i
 
 ## Usage
 
+Ensure that the go-quai node is exposing the txpool api on both HTTP and WS.
+
 You can run the script by using the following command.
 
 ```bash
-node index.js --group <your_group> --zone <your_zone> --host <your_host>
+node index.js --group group-<group_num> --zone zone-<region_num>-<zone_num> --host <your_host>
 ```
 Or you can use the short form of the options:
 
 ```bash
-node index.js -g <your_group> -z <your_zone> -h <your_host>
+node index.js -g group-<group_num> -z zone-<region_num>-<zone_num> -h <your_host>
 ```
 
 Here is the explanation for each option:


### PR DESCRIPTION
This README clarifies how to use the run command and reminds the user that they need to change the network.env to expose Txpool api (which is not on by default).